### PR TITLE
Improvements 0.10.1 fix child auto multiple children

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -13,6 +13,6 @@ task test, "test all":
   exec "nim -d:cssgrid.scalar=int c -r " & "tests/tgrids.nim"
 
 # begin Nimble config (version 2)
-when withDir(thisDir(), system.fileExists("nimble.paths")):
-  include "nimble.paths"
+# when withDir(thisDir(), system.fileExists("nimble.paths")):
+#   include "nimble.paths"
 # end Nimble config

--- a/cssgrid.nimble
+++ b/cssgrid.nimble
@@ -1,5 +1,5 @@
 # Package
-version       = "0.10.0"
+version       = "0.10.1"
 author        = "Jaremy Creechley"
 description   = "pure Nim CSS Grid layout engine"
 license       = "MIT"

--- a/src/cssgrid/basiclayout.nim
+++ b/src/cssgrid/basiclayout.nim
@@ -233,13 +233,13 @@ proc calcBasicConstraintPostImpl(node: GridNode, dir: GridDir, calc: CalcKind, f
     of PADWH:
       node.cxPadSize[dir]
   
-  debugPrint "CONTENT csValue:post", "node=", node.name, "calc=", calc, "dir=", repr(dir), "w=", node.box.w, "h=", node.box.h
+  debugPrint "CONTENT csValue:post", "node=", node.name, "calc=", calc, "dir=", repr(dir), "w=", node.box.w, "h=", node.box.h, "csValue=", repr(csValue)
   match csValue:
     UiNone:
       discard
       # # handle UiNone for height to account for minimum sizes of contents
       if calc == WH and dir == drow:
-        f = node.bmin.h
+        f = max(f, node.bmin.h)
     UiAdd(ls, rs):
       if ls.isBasicContentSized() or rs.isBasicContentSized():
         let lv = ls.calcBasic()

--- a/tests/tgridlayout.nim
+++ b/tests/tgridlayout.nim
@@ -115,32 +115,26 @@ suite "Compute Layout Tests":
       let story = newTestNode("story", parent)
 
       parseGridTemplateColumns story.gridTemplate, 1'fr
-      parent.cxSize = [100'pp, 100'pp]
+      parent.cxSize = [400'ux, 300'ux]
 
       story.cxSize = [cx"auto", cx"auto"]
       story.gridTemplate.autoFlow = grRow
       story.gridTemplate.autos[drow] = csAuto()
 
       block rect0:
-        let child = newTestNode("rect-0", story)
-
-        child.cxPadOffset[drow] = 21.01'ux
-        child.cxPadSize[drow] = 22.20'ux
+        let rect = newTestNode("rect-0", story)
 
         block text0:
-          let text = newTestNode("text-0", child)
-          text.cxSize = [cx"auto", 33.33'ux]
+          let text = newTestNode("text-0", rect)
+          text.cxSize = [cx"auto", 133.33'ux]
           text.cxMin = [40'ux, 20.00'ux]
           text.cxMax = [200'ux, 300.00'ux]
 
       block rect1:
-        let child = newTestNode("rect-1", story)
-
-        child.cxPadOffset[drow] = 21.01'ux
-        child.cxPadSize[drow] = 22.20'ux
+        let rect = newTestNode("rect-1", story)
 
         block text1:
-          let text = newTestNode("text-1", child)
+          let text = newTestNode("text-1", rect)
           text.cxSize = [cx"auto", 33.33'ux]
           text.cxMin = [40'ux, 20.00'ux]
           text.cxMax = [200'ux, 300.00'ux]

--- a/tests/tgridlayout.nim
+++ b/tests/tgridlayout.nim
@@ -116,10 +116,6 @@ suite "Compute Layout Tests":
 
       parent.cxSize = [400'ux, 300'ux]
 
-      # parseGridTemplateColumns items.gridTemplate, 1'fr
-      # items.cxSize = [cx"auto", cx"max-content"]
-      # items.gridTemplate.autoFlow = grRow
-      # items.gridTemplate.autos[drow] = csAuto()
       items.cxSize = [cx"auto", cx"none"]
 
       block story0:

--- a/tests/tgridlayout.nim
+++ b/tests/tgridlayout.nim
@@ -68,8 +68,8 @@ suite "Compute Layout Tests":
 
   test "vertical layout auto":
     when true:
-      prettyPrintWriteMode = cmTerminal
-      defer: prettyPrintWriteMode = cmNone
+      # prettyPrintWriteMode = cmTerminal
+      # defer: prettyPrintWriteMode = cmNone
 
       let parent = newTestNode("scroll", 0, 0, 400, 300)
       let body = newTestNode("scrollBody", parent)
@@ -99,20 +99,55 @@ suite "Compute Layout Tests":
         text.cxSize = [cx"auto", 33.33'ux]
         text.cxMin = [40'ux, 20.00'ux]
         text.cxMax = [200'ux, 300.00'ux]
-
-        # W: 1.00'fr          H: 42.30'ui
-        # X: 10.00'ui          Y: 0.00'ui
-        # Xmin: 600.50'ui          Ymin: 22.50'ui
-        # box: [x: 10.00, y: 0.00, w: 638.67, h: 42.30]
-        # bmin: [x: 600.50, y: 22.50]
-        # bmax: [x: -inf, y: 42.30]
-        # bpad: [x: 0.00, y: 20.00, w: 0.00, h: 20.00]
-
+      
       computeLayout(parent)
       # printLayout(parent, cmTerminal)
 
       check items.children[0].box.w == 768
       check abs(items.children[0].box.h - 63.21.UiScalar).float < 1.0e-3
+  
+  test "vertical layout auto with grandchild":
+    when true:
+      prettyPrintWriteMode = cmTerminal
+      defer: prettyPrintWriteMode = cmNone
+
+      let parent = newTestNode("scroll", 0, 0, 400, 300)
+      let story = newTestNode("story", parent)
+
+      parseGridTemplateColumns story.gridTemplate, 1'fr
+      parent.cxSize = [100'pp, 100'pp]
+
+      story.cxSize = [cx"auto", cx"auto"]
+      story.gridTemplate.autoFlow = grRow
+      story.gridTemplate.autos[drow] = csAuto()
+
+      block rect0:
+        let child = newTestNode("rect-0", story)
+
+        child.cxPadOffset[drow] = 21.01'ux
+        child.cxPadSize[drow] = 22.20'ux
+
+        block text0:
+          let text = newTestNode("text-0", child)
+          text.cxSize = [cx"auto", 33.33'ux]
+          text.cxMin = [40'ux, 20.00'ux]
+          text.cxMax = [200'ux, 300.00'ux]
+
+      block rect1:
+        let child = newTestNode("rect-1", story)
+
+        child.cxPadOffset[drow] = 21.01'ux
+        child.cxPadSize[drow] = 22.20'ux
+
+        block text1:
+          let text = newTestNode("text-1", child)
+          text.cxSize = [cx"auto", 33.33'ux]
+          text.cxMin = [40'ux, 20.00'ux]
+          text.cxMax = [200'ux, 300.00'ux]
+
+      computeLayout(parent)
+      # printLayout(parent, cmTerminal)
+
 
   test "vertical layout max-content":
     # prettyPrintWriteMode = cmTerminal

--- a/tests/tgridlayout.nim
+++ b/tests/tgridlayout.nim
@@ -145,6 +145,9 @@ suite "Compute Layout Tests":
 
       computeLayout(parent)
       # printLayout(parent, cmTerminal)
+      check items.children[0].children[0].box.h.float32 == 42.50
+      check items.children[0].children[1].box.h.float32 == 20.50
+      check items.children[0].box.h.float32 == 63.00
 
 
   test "vertical layout max-content":

--- a/tests/tgridlayout.nim
+++ b/tests/tgridlayout.nim
@@ -116,12 +116,12 @@ suite "Compute Layout Tests":
 
       parent.cxSize = [400'ux, 300'ux]
 
-      items.cxSize = [cx"auto", cx"none"]
+      items.cxSize = [cx"auto", cx"max-content"]
 
       block story0:
         let story = newTestNode("story", items)
         parseGridTemplateColumns story.gridTemplate, 1'fr
-        story.cxSize = [cx"auto", cx"none"]
+        story.cxSize = [cx"auto", cx"auto"]
         story.gridTemplate.autoFlow = grRow
         story.gridTemplate.autos[drow] = csAuto()
 
@@ -148,6 +148,7 @@ suite "Compute Layout Tests":
       check items.children[0].children[0].box.h.float32 == 42.50
       check items.children[0].children[1].box.h.float32 == 20.50
       check items.children[0].box.h.float32 == 63.00
+      check items.box.h.float32 == 63.00
 
 
   test "vertical layout max-content":

--- a/tests/tgridlayout.nim
+++ b/tests/tgridlayout.nim
@@ -112,32 +112,40 @@ suite "Compute Layout Tests":
       defer: prettyPrintWriteMode = cmNone
 
       let parent = newTestNode("scroll", 0, 0, 400, 300)
-      let story = newTestNode("story", parent)
+      let items = newTestNode("items", parent)
 
-      parseGridTemplateColumns story.gridTemplate, 1'fr
       parent.cxSize = [400'ux, 300'ux]
 
-      story.cxSize = [cx"auto", cx"auto"]
-      story.gridTemplate.autoFlow = grRow
-      story.gridTemplate.autos[drow] = csAuto()
+      # parseGridTemplateColumns items.gridTemplate, 1'fr
+      # items.cxSize = [cx"auto", cx"max-content"]
+      # items.gridTemplate.autoFlow = grRow
+      # items.gridTemplate.autos[drow] = csAuto()
+      items.cxSize = [cx"auto", cx"none"]
 
-      block rect0:
-        let rect = newTestNode("rect-0", story)
+      block story0:
+        let story = newTestNode("story", items)
+        parseGridTemplateColumns story.gridTemplate, 1'fr
+        story.cxSize = [cx"auto", cx"none"]
+        story.gridTemplate.autoFlow = grRow
+        story.gridTemplate.autos[drow] = csAuto()
 
-        block text0:
-          let text = newTestNode("text-0", rect)
-          text.cxSize = [cx"auto", 133.33'ux]
-          text.cxMin = [40'ux, 20.00'ux]
-          text.cxMax = [200'ux, 300.00'ux]
+        block rect0:
+          let rect = newTestNode("rect-0", story)
 
-      block rect1:
-        let rect = newTestNode("rect-1", story)
+          block text0:
+            let text = newTestNode("text-0", rect)
+            text.cxSize = [cx"auto", cx"none"]
+            text.cxMin = [40'ux, 42.50'ux]
+            text.cxMax = [200'ux, 300.00'ux]
 
-        block text1:
-          let text = newTestNode("text-1", rect)
-          text.cxSize = [cx"auto", 33.33'ux]
-          text.cxMin = [40'ux, 20.00'ux]
-          text.cxMax = [200'ux, 300.00'ux]
+        block rect1:
+          let rect = newTestNode("rect-1", story)
+
+          block text1:
+            let text = newTestNode("text-1", rect)
+            text.cxSize = [cx"auto", cx"none"]
+            text.cxMin = [40'ux, 20.50'ux]
+            text.cxMax = [200'ux, 300.00'ux]
 
       computeLayout(parent)
       # printLayout(parent, cmTerminal)


### PR DESCRIPTION
Fix issue with csNone overriding the size of a nodes height when its bmin was smaller.